### PR TITLE
Fix Vercel SPA fallback route in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -12,7 +12,7 @@
   "routes": [
     {
       "src": "/(.*)",
-      "dest": "/client/index.html"
+      "dest": "/index.html"
     }
   ]
 }


### PR DESCRIPTION
Changed routes[0].dest from /client/index.html to /index.html. This ensures Vercel correctly serves the index.html from the root of the client build's output directory (client/dist) for SPA routing.